### PR TITLE
Documentation Patch

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,8 @@ formats: all
 
 build:
   os: ubuntu-20.04
-  tools: python: "3.7"
+  tools: 
+    python: "3.7"
   
 python:
    install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,8 +9,11 @@ sphinx:
 
 formats: all
 
+build:
+  os: ubuntu-20.04
+  tools: python: "3.7"
+  
 python:
-   version: 3.7
    install:
        - requirements: docs/requirements.txt 
        

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -86,3 +86,4 @@ urllib3==1.25.10
 virtualenv==20.0.30
 websocket-client==0.57.0
 Werkzeug==1.0.1
+sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,4 +85,3 @@ urllib3==1.25.10
 virtualenv==20.0.30
 websocket-client==0.57.0
 Werkzeug==1.0.1
-sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,3 +85,4 @@ urllib3==1.25.10
 virtualenv==20.0.30
 websocket-client==0.57.0
 Werkzeug==1.0.1
+sphinx_rtd_theme


### PR DESCRIPTION
readthedocs updated something on its backend which was breaking the documentation build.

The original problem was arising from the fact that we had not specified an OS explicitly in `/docs/source/conf.py`